### PR TITLE
Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/app/src/main/java/org/evilsoft/pathfinder/reference/AbstractViewListFragment.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/AbstractViewListFragment.java
@@ -277,7 +277,7 @@ public abstract class AbstractViewListFragment extends SherlockListFragment
 				.setView(edit)
 				.setPositiveButton("OK", new DialogInterface.OnClickListener() {
 					public void onClick(DialogInterface dialog, int which) {
-						StringBuffer sb = new StringBuffer();
+						StringBuilder sb = new StringBuilder();
 						sb.append("SectionViewFragment.showNewCollectionDialog.onClick: OK: which:");
 						sb.append(which);
 						CollectionAdapter ca = new CollectionAdapter(dbWrangler

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/DetailsWebViewClient.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/DetailsWebViewClient.java
@@ -148,7 +148,7 @@ public class DetailsWebViewClient extends WebViewClient {
 		if (newUrl == null) {
 			return uri;
 		}
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(newUrl);
 		if (subtype != null) {
 			sb.append("?subtype=");
@@ -194,7 +194,7 @@ public class DetailsWebViewClient extends WebViewClient {
 			cursor = dbWrangler.getBookDbAdapterByUrl(newUrl)
 					.getSectionAdapter().fetchSectionByUrl(newUrl);
 			String html = null;
-			StringBuffer htmlparts = new StringBuffer();
+			StringBuilder htmlparts = new StringBuilder();
 			try {
 				boolean hasNext = cursor.moveToFirst();
 				while (hasNext) {
@@ -286,7 +286,7 @@ public class DetailsWebViewClient extends WebViewClient {
 
 	private String encodeUrl(String url) {
 		String[] parts = url.split("\\/");
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(parts[0]);
 		for (int i = 1; i < parts.length; i++) {
 			sb.append("/");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/HtmlRenderFarm.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/HtmlRenderFarm.java
@@ -140,7 +140,7 @@ public class HtmlRenderFarm {
 		HashMap<Integer, Integer> depthMap = new HashMap<Integer, Integer>();
 		HashMap<Integer, String> titleMap = new HashMap<Integer, String>();
 		int depth = 0;
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		boolean has_next = cursor.moveToFirst();
 		try {
 			boolean top = true;
@@ -216,7 +216,7 @@ public class HtmlRenderFarm {
 	}
 
 	public String renderFooter() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("<script type=\"text/javascript\" src=\"file:///android_asset/application.min.js\"></script>");
 		if (showToc) {
 			if (isTablet) {
@@ -231,7 +231,7 @@ public class HtmlRenderFarm {
 	}
 
 	public String renderHeader() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("<html>");
 		sb.append("<head>");
 		sb.append("<meta name=\"viewport\" content=\"width=device-width; initial-scale=1; maximum-sale=1; minimum-scale=1; user-scalable=n;\" />");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/SectionListFragment.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/SectionListFragment.java
@@ -104,7 +104,7 @@ public class SectionListFragment extends ExpandableListFragment implements
 		if(group.equals("Bookmarks")) {
 			String sectionUrl = expListAdapter.getPfGroupUrl(groupPosition);
 			String specificName = (String) expListAdapter.getChild(groupPosition, childPosition);
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			sb.append(sectionUrl);
 			sb.append("/");
 			sb.append(specificName);

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/api/AbstractContentProvider.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/api/AbstractContentProvider.java
@@ -99,7 +99,7 @@ public abstract class AbstractContentProvider extends ContentProvider {
 
 	public String renderHtmlByIndexId(String indexId) {
 		String html = null;
-		StringBuffer htmlparts = new StringBuffer();
+		StringBuilder htmlparts = new StringBuilder();
 		Cursor cursor = dbWrangler.getIndexDbAdapter().getIndexGroupAdapter()
 				.fetchById(Integer.valueOf(indexId));
 		try {

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/BaseDbHelper.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/BaseDbHelper.java
@@ -276,7 +276,7 @@ public abstract class BaseDbHelper extends SQLiteOpenHelper {
 				}
 			}
 		}
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		for (int i = 0; i < localColumns.size(); i++) {
 			if (i > 0) {
 				sb.append(", ");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/DbWrangler.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/DbWrangler.java
@@ -200,7 +200,7 @@ public class DbWrangler {
 	public static void showLowSpaceError(Activity runningActivity,
 			LimitedSpaceException e,
 			DialogInterface.OnClickListener clickListener) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("Error creating database.  This app requires at least ");
 		sb.append(e.getSize() / AvailableSpaceHandler.SIZE_MB + 1);
 		sb.append(" megs free in order to store articles.  Exiting.");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/AbilityAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/AbilityAdapter.java
@@ -20,7 +20,7 @@ public class AbilityAdapter {
 	public Cursor getAbilityTypes(Integer sectionId) {
 		List<String> args = new ArrayList<String>();
 		args.add(sectionId.toString());
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT ability_type");
 		sb.append(" FROM ability_types");
 		sb.append(" WHERE section_id = ?");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/AfflictionAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/AfflictionAdapter.java
@@ -20,7 +20,7 @@ public class AfflictionAdapter {
 	public Cursor getAfflictionDetails(Integer sectionId) {
 		List<String> args = new ArrayList<String>();
 		args.add(sectionId.toString());
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT contracted, addiction, save, onset, frequency, effect, initial_effect, ");
 		sb.append("  secondary_effect, damage, cure, cost");
 		sb.append(" FROM affliction_details");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/AnimalCompanionAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/AnimalCompanionAdapter.java
@@ -20,7 +20,7 @@ public class AnimalCompanionAdapter {
 	public Cursor getAnimalCompanionDetails(Integer sectionId) {
 		List<String> args = new ArrayList<String>();
 		args.add(sectionId.toString());
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT ac, attack, cmd, ability_scores, special_abilities,");
 		sb.append("  special_qualities, special_attacks, size, speed,");
 		sb.append("  bonus_feat, level");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/ArmyAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/ArmyAdapter.java
@@ -20,7 +20,7 @@ public class ArmyAdapter {
 	public Cursor getArmyDetails(Integer sectionId) {
 		List<String> args = new ArrayList<String>();
 		args.add(sectionId.toString());
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT xp, creature_type, alignment, size, hp, acr, dv,");
 		sb.append("  om, special, speed, consumption, tactics,");
 		sb.append("  resources, note");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/BookDbHelper.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/BookDbHelper.java
@@ -13,7 +13,7 @@ public class BookDbHelper extends BaseDbHelper {
 	}
 
 	public boolean testDb(SQLiteDatabase database) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT count(*)");
 		sb.append(" FROM section_index");
 		String sql = sb.toString();

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/ClassAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/ClassAdapter.java
@@ -20,7 +20,7 @@ public class ClassAdapter {
 	public Cursor fetchClassDetails(Integer section_id) {
 		List<String> args = new ArrayList<String>();
 		args.add(section_id.toString());
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT alignment, hit_die");
 		sb.append(" FROM class_details");
 		sb.append(" WHERE section_id = ?");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/CreatureAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/CreatureAdapter.java
@@ -20,7 +20,7 @@ public class CreatureAdapter {
 	public Cursor getCreatureDetails(Integer sectionId) {
 		List<String> args = new ArrayList<String>();
 		args.add(sectionId.toString());
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT sex, super_race, level, cr, xp, alignment, size, creature_type, creature_subtype, init,");
 		sb.append("  senses, aura,");
 		sb.append("  ac, hp, fortitude, reflex, will, defensive_abilities, dr, resist, immune, concentration, sr, weaknesses,");
@@ -257,7 +257,7 @@ public class CreatureAdapter {
 	public Cursor getCreatureSpells(Integer sectionId) {
 		List<String> args = new ArrayList<String>();
 		args.add(sectionId.toString());
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT name, body");
 		sb.append(" FROM creature_spells");
 		sb.append(" WHERE section_id = ?");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/FeatAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/FeatAdapter.java
@@ -20,7 +20,7 @@ public class FeatAdapter {
 	public Cursor fetchFeatTypeDescriptionForSection(Integer sectionId) {
 		List<String> args = new ArrayList<String>();
 		args.add(sectionId.toString());
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT feat_type_description");
 		sb.append(" FROM feat_type_descriptions");
 		sb.append(" WHERE section_id = ?");
@@ -32,7 +32,7 @@ public class FeatAdapter {
 	public String renderFeatTypeDescription(Integer sectionId) {
 		Cursor curs = fetchFeatTypeDescriptionForSection(sectionId);
 		try {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			boolean has_next = curs.moveToFirst();
 			while (has_next) {
 				sb.append(curs.getString(0));
@@ -47,7 +47,7 @@ public class FeatAdapter {
 	public Cursor getFeatTypes(Integer sectionId) {
 		List<String> args = new ArrayList<String>();
 		args.add(sectionId.toString());
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT feat_type");
 		sb.append(" FROM feat_types");
 		sb.append(" WHERE section_id = ?");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/FullSectionAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/FullSectionAdapter.java
@@ -20,7 +20,7 @@ public class FullSectionAdapter {
 	public Cursor fetchFullSection(String sectionId) {
 		List<String> args = new ArrayList<String>();
 		args.add(sectionId);
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT node.section_id, node.lft, node.rgt, node.parent_id, node.type,");
 		sb.append("  node.subtype, node.name, node.abbrev, node.source, node.description, node.body,");
 		sb.append("  node.image, node.alt, node.create_index, node.url");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/HauntAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/HauntAdapter.java
@@ -20,7 +20,7 @@ public class HauntAdapter {
 	public Cursor getHauntDetails(Integer sectionId) {
 		List<String> args = new ArrayList<String>();
 		args.add(sectionId.toString());
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT cr, xp, haunt_type, notice, area, hp, destruction, alignment, caster_level, effect, trigger, reset");
 		sb.append(" FROM haunt_details");
 		sb.append(" WHERE section_id = ?");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/ItemAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/ItemAdapter.java
@@ -20,7 +20,7 @@ public class ItemAdapter {
 	public Cursor getItemDetails(Integer sectionId) {
 		List<String> args = new ArrayList<String>();
 		args.add(sectionId.toString());
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT aura, slot, cl, price, weight");
 		sb.append(" FROM item_details");
 		sb.append(" WHERE section_id = ?");
@@ -53,7 +53,7 @@ public class ItemAdapter {
 	public Cursor getItemMisc(Integer sectionId) {
 		List<String> args = new ArrayList<String>();
 		args.add(sectionId.toString());
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT field, subsection, value");
 		sb.append(" FROM item_misc");
 		sb.append(" WHERE section_id = ?");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/KingdomResourceAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/KingdomResourceAdapter.java
@@ -20,7 +20,7 @@ public class KingdomResourceAdapter {
 	public Cursor getKingdomResourceDetails(Integer sectionId) {
 		List<String> args = new ArrayList<String>();
 		args.add(sectionId.toString());
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT bp, lot, kingdom, discount, magic_items,");
 		sb.append("  settlement, special, resource_limit, upgrade_from,");
 		sb.append("  upgrade_to");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/LinkAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/LinkAdapter.java
@@ -20,7 +20,7 @@ public class LinkAdapter {
 	public Cursor getLinkDetails(Integer sectionId) {
 		List<String> args = new ArrayList<String>();
 		args.add(sectionId.toString());
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT section_id, url, display");
 		sb.append(" FROM link_details");
 		sb.append(" WHERE section_id = ?");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/MythicSpellDetailAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/MythicSpellDetailAdapter.java
@@ -20,7 +20,7 @@ public class MythicSpellDetailAdapter {
 	public Cursor fetchMythicSpellDetails(Integer sectionId) {
 		List<String> args = new ArrayList<String>();
 		args.add(sectionId.toString());
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT section_id, spell_source");
 		sb.append(" FROM mythic_spell_details");
 		sb.append(" WHERE section_id = ?");
@@ -31,7 +31,7 @@ public class MythicSpellDetailAdapter {
 	public Cursor fetchMythicSpellDetailsByName(String spellName) {
 		List<String> args = new ArrayList<String>();
 		args.add(spellName);
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT section_id, spell_source");
 		sb.append(" FROM mythic_spell_details");
 		sb.append(" WHERE spell_source = ?");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/ResourceAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/ResourceAdapter.java
@@ -20,7 +20,7 @@ public class ResourceAdapter {
 	public Cursor getResourceDetails(Integer sectionId) {
 		List<String> args = new ArrayList<String>();
 		args.add(sectionId.toString());
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT benefit, resource_create, earnings, rooms, size, ");
 		sb.append("  skills, teams, time, upgrade_from, upgrade_to, wage");
 		sb.append(" FROM resource_details");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SectionAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SectionAdapter.java
@@ -20,7 +20,7 @@ public class SectionAdapter {
 	public Cursor fetchSectionBySectionId(Integer sectionId) {
 		List<String> args = new ArrayList<String>();
 		args.add(sectionId.toString());
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT section_id, parent_id, name, type, subtype, url,");
 		sb.append("  abbrev, source, description, body, image, alt");
 		sb.append(" FROM sections");
@@ -32,7 +32,7 @@ public class SectionAdapter {
 	public Cursor fetchSectionByParentId(Integer parentId) {
 		List<String> args = new ArrayList<String>();
 		args.add(parentId.toString());
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT section_id, parent_id, name, type, subtype, url,");
 		sb.append("  abbrev, source, description, body, image, alt");
 		sb.append(" FROM sections");
@@ -45,7 +45,7 @@ public class SectionAdapter {
 		List<String> args = new ArrayList<String>();
 		args.add(parentId);
 		args.add(name);
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT section_id, parent_id, name, type, subtype, url,");
 		sb.append("  abbrev, source, description, body, image, alt");
 		sb.append(" FROM sections");
@@ -58,7 +58,7 @@ public class SectionAdapter {
 	public Cursor fetchParentBySectionId(Integer sectionId) {
 		List<String> args = new ArrayList<String>();
 		args.add(sectionId.toString());
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT p.section_id, p.parent_id, p.name, p.type, p.subtype, p.url,");
 		sb.append("  p.abbrev, p.source, p.description, p.body, p.image, p.alt");
 		sb.append(" FROM sections s");
@@ -72,7 +72,7 @@ public class SectionAdapter {
 	public Cursor fetchSectionByParentUrl(String parentUrl) {
 		List<String> args = new ArrayList<String>();
 		args.add(parentUrl);
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT s.section_id, s.parent_id, s.name, s.type, s.subtype, s.url,");
 		sb.append("  s.abbrev, s.source, s.description, s.body, s.image, s.alt");
 		sb.append(" FROM sections s");
@@ -86,7 +86,7 @@ public class SectionAdapter {
 	public Cursor fetchSectionByUrl(String url) {
 		List<String> args = new ArrayList<String>();
 		args.add(url);
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT section_id, parent_id, name, type, subtype, url,");
 		sb.append("  abbrev, source, description, body, image, alt");
 		sb.append(" FROM sections");
@@ -95,7 +95,7 @@ public class SectionAdapter {
 		Cursor curs = database.rawQuery(sql, BaseDbHelper.toStringArray(args));
 		if (curs.getCount() == 0) {
 			curs.close();
-			sb = new StringBuffer();
+			sb = new StringBuilder();
 			sb.append("SELECT s.section_id, s.parent_id, s.name, s.type, s.subtype, s.url,");
 			sb.append("  s.abbrev, s.source, s.description, s.body, s.image, s.alt");
 			sb.append(" FROM sections s");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SectionIndexGroupAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SectionIndexGroupAdapter.java
@@ -20,7 +20,7 @@ public class SectionIndexGroupAdapter {
 	public Cursor fetchSectionByParentUrl(String parentUrl) {
 		List<String> args = new ArrayList<String>();
 		args.add(parentUrl);
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT s.section_id, '" + dbName + "' as database, ");
 		sb.append("  s.name, s.parent_id, p.name as parent_name, s.source,");
 		sb.append("  s.type, s.subtype, s.description, s.url");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SettlementAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SettlementAdapter.java
@@ -20,7 +20,7 @@ public class SettlementAdapter {
 	public Cursor getSettlementDetails(Integer sectionId) {
 		List<String> args = new ArrayList<String>();
 		args.add(sectionId.toString());
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT alignment, settlement_type, size, corruption, crime, economy, law,");
 		sb.append("  lore, society, qualities, danger, disadvantages, government,");
 		sb.append("  population, base_value, purchase_limit, spellcasting,");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SkillAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SkillAdapter.java
@@ -20,7 +20,7 @@ public class SkillAdapter {
 	public Cursor fetchSkillAttr(Integer section_id) {
 		List<String> args = new ArrayList<String>();
 		args.add(section_id.toString());
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT attribute, armor_check_penalty, trained_only");
 		sb.append(" FROM skill_attributes");
 		sb.append(" WHERE section_id = ?");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SpellComponentAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SpellComponentAdapter.java
@@ -20,7 +20,7 @@ public class SpellComponentAdapter {
 	public Cursor fetchSpellComponents(Integer section_id) {
 		List<String> args = new ArrayList<String>();
 		args.add(section_id.toString());
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT component_type, description");
 		sb.append(" FROM spell_components");
 		sb.append(" WHERE section_id = ?");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SpellDescriptorAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SpellDescriptorAdapter.java
@@ -20,7 +20,7 @@ public class SpellDescriptorAdapter {
 	public Cursor getSpellDescriptors(Integer sectionId) {
 		List<String> args = new ArrayList<String>();
 		args.add(sectionId.toString());
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT descriptor");
 		sb.append(" FROM spell_descriptors");
 		sb.append(" WHERE section_id = ?");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SpellDetailAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SpellDetailAdapter.java
@@ -20,7 +20,7 @@ public class SpellDetailAdapter {
 	public Cursor fetchSpellDetails(Integer section_id) {
 		List<String> args = new ArrayList<String>();
 		args.add(section_id.toString());
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT school, subschool_text, descriptor_text, level_text, component_text,");
 		sb.append("  casting_time, preparation_time, range, duration, saving_throw, spell_resistance, as_spell_id");
 		sb.append(" FROM spell_details");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SpellEffectAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SpellEffectAdapter.java
@@ -20,7 +20,7 @@ public class SpellEffectAdapter {
 	public Cursor fetchSpellEffects(Integer section_id) {
 		List<String> args = new ArrayList<String>();
 		args.add(section_id.toString());
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT name, description");
 		sb.append(" FROM spell_effects");
 		sb.append(" WHERE section_id = ?");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SpellListAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SpellListAdapter.java
@@ -20,7 +20,7 @@ public class SpellListAdapter {
 	public Cursor getSpellLists(Integer sectionId) {
 		List<String> args = new ArrayList<String>();
 		args.add(sectionId.toString());
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT level, type, name, notes, magic_type");
 		sb.append(" FROM spell_lists");
 		sb.append(" WHERE section_id = ?");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SpellSubschoolAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SpellSubschoolAdapter.java
@@ -20,7 +20,7 @@ public class SpellSubschoolAdapter {
 	public Cursor getSpellSubschools(Integer sectionId) {
 		List<String> args = new ArrayList<String>();
 		args.add(sectionId.toString());
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT subschool");
 		sb.append(" FROM spell_subschools");
 		sb.append(" WHERE section_id = ?");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/TalentAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/TalentAdapter.java
@@ -20,7 +20,7 @@ public class TalentAdapter {
 	public Cursor getTalentDetails(Integer sectionId) {
 		List<String> args = new ArrayList<String>();
 		args.add(sectionId.toString());
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT element, talent_type, blast_type, level, burn, damage, prerequisite, ");
 		sb.append("  associated_blasts, saving_throw, spell_resistance");
 		sb.append(" FROM talent_details");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/TrapAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/TrapAdapter.java
@@ -20,7 +20,7 @@ public class TrapAdapter {
 	public Cursor getTrapDetails(Integer sectionId) {
 		List<String> args = new ArrayList<String>();
 		args.add(sectionId.toString());
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT cr, trap_type, perception, disable_device, duration, effect, trigger, reset");
 		sb.append(" FROM trap_details");
 		sb.append(" WHERE section_id = ?");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/VehicleAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/VehicleAdapter.java
@@ -20,7 +20,7 @@ public class VehicleAdapter {
 	public Cursor getVehicleDetails(Integer sectionId) {
 		List<String> args = new ArrayList<String>();
 		args.add(sectionId.toString());
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT size, vehicle_type, squares, cost, ac, hardness, hp, base_save,");
 		sb.append("  maximum_speed, acceleration, cmb, cmd, ramming_damage, propulsion,");
 		sb.append("  driving_check, forward_facing, driving_device, driving_space, decks,");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/ApiCasterListAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/ApiCasterListAdapter.java
@@ -35,7 +35,7 @@ public class ApiCasterListAdapter {
 
 	public Cursor getCasters(String[] projection, String selection,
 			String[] selectionArgs, String sortOrder) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT ");
 		sb.append(BaseDbHelper.implementProjection(columns, projection,
 				translation));

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/ApiClassSpellListAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/ApiClassSpellListAdapter.java
@@ -51,7 +51,7 @@ public class ApiClassSpellListAdapter {
 	public String getClassName(String classId) {
 		List<String> args = new ArrayList<String>();
 		args.add(classId);
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT name");
 		sb.append(" FROM central_index");
 		sb.append(" WHERE type = 'class'");
@@ -72,7 +72,7 @@ public class ApiClassSpellListAdapter {
 	public Cursor getClassSpells(String classId, String[] projection,
 			String selection, String[] selectionArgs, String sortOrder) {
 		List<String> args = new ArrayList<String>();
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT DISTINCT ");
 		sb.append(BaseDbHelper.implementProjection(columns, projection,
 				translation));

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/ApiCreatureListAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/ApiCreatureListAdapter.java
@@ -50,7 +50,7 @@ public class ApiCreatureListAdapter {
 
 	public Cursor getCreatures(String[] projection, String selection,
 			String[] selectionArgs, String sortOrder) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT ");
 		sb.append(BaseDbHelper.implementProjection(columns, projection,
 				translation));

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/ApiFeatListAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/ApiFeatListAdapter.java
@@ -40,7 +40,7 @@ public class ApiFeatListAdapter {
 
 	public Cursor getFeats(String[] projection, String selection,
 			String[] selectionArgs, String sortOrder) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT ");
 		sb.append(BaseDbHelper.implementProjection(columns, projection,
 				translation));

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/ApiFilteredClassSpellListAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/ApiFilteredClassSpellListAdapter.java
@@ -51,7 +51,7 @@ public class ApiFilteredClassSpellListAdapter {
 	public String getClassName(String classId) {
 		List<String> args = new ArrayList<String>();
 		args.add(classId);
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT name");
 		sb.append(" FROM central_index");
 		sb.append(" WHERE type = 'class'");
@@ -72,7 +72,7 @@ public class ApiFilteredClassSpellListAdapter {
 	public Cursor getFilteredClassSpells(String classId, String[] projection,
 			String selection, String[] selectionArgs, String sortOrder) {
 		List<String> args = new ArrayList<String>();
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT ");
 		sb.append(BaseDbHelper.implementProjection(columns, projection,
 				translation));

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/ApiFilteredSpellListAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/ApiFilteredSpellListAdapter.java
@@ -47,7 +47,7 @@ public class ApiFilteredSpellListAdapter {
 
 	public Cursor getFilteredSpells(String[] projection, String selection,
 			String[] selectionArgs, String sortOrder) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT DISTINCT ");
 		sb.append(BaseDbHelper.implementProjection(columns, projection,
 				translation));

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/ApiSectionListAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/ApiSectionListAdapter.java
@@ -37,7 +37,7 @@ public class ApiSectionListAdapter {
 
 	public Cursor getClasses(String[] projection, String selection,
 			String[] selectionArgs, String sortOrder) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT ");
 		sb.append(BaseDbHelper.implementProjection(columns, projection,
 				translation));

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/ApiSkillListAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/ApiSkillListAdapter.java
@@ -44,7 +44,7 @@ public class ApiSkillListAdapter {
 
 	public Cursor getSkills(String[] projection, String selection,
 			String[] selectionArgs, String sortOrder) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT ");
 		sb.append(BaseDbHelper.implementProjection(columns, projection,
 				translation));

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/ApiSpellListAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/ApiSpellListAdapter.java
@@ -47,7 +47,7 @@ public class ApiSpellListAdapter {
 
 	public Cursor getSpells(String[] projection, String selection,
 			String[] selectionArgs, String sortOrder) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT ");
 		sb.append(BaseDbHelper.implementProjection(columns, projection,
 				translation));

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/BooksAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/BooksAdapter.java
@@ -21,7 +21,7 @@ public class BooksAdapter {
 
 	public Cursor fetchBook(String source) {
 		List<String> args = new ArrayList<String>();
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT book_id, source, db");
 		sb.append(" FROM books");
 		sb.append(" WHERE source = ?");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/CountAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/CountAdapter.java
@@ -24,7 +24,7 @@ public class CountAdapter {
 			type = null;
 		}
 		List<String> args = new ArrayList<String>();
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT count(*) AS cnt");
 		sb.append(" FROM central_index i");
 		String where = "WHERE";
@@ -46,7 +46,7 @@ public class CountAdapter {
 
 	public Cursor fetchByUrl(String url) {
 		List<String> args = new ArrayList<String>();
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT count(*) AS cnt");
 		sb.append(" FROM central_index i");
 		sb.append(" WHERE i.url = ?");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/CreatureTypeAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/CreatureTypeAdapter.java
@@ -21,7 +21,7 @@ public class CreatureTypeAdapter {
 
 	public Cursor fetchCreatureTypes() {
 		List<String> args = new ArrayList<String>();
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT DISTINCT creature_type");
 		sb.append(" FROM central_index");
 		sb.append("  WHERE creature_type IS NOT NULL");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/FeatTypeAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/FeatTypeAdapter.java
@@ -21,7 +21,7 @@ public class FeatTypeAdapter {
 
 	public Cursor fetchFeatTypes() {
 		List<String> args = new ArrayList<String>();
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT DISTINCT ft.feat_type");
 		sb.append(" FROM feat_type_index ft");
 		sb.append("  INNER JOIN central_index ci");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/IndexDbHelper.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/IndexDbHelper.java
@@ -14,7 +14,7 @@ public class IndexDbHelper extends BaseDbHelper {
 	}
 
 	public boolean testDb(SQLiteDatabase database) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT count(*)");
 		sb.append(" FROM central_index");
 		String sql = sb.toString();

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/IndexGroupAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/IndexGroupAdapter.java
@@ -24,7 +24,7 @@ public class IndexGroupAdapter {
 	}
 
 	private String selectStatement(String addedColumns) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT i.index_id, i.section_id, i.parent_id, i.parent_name,");
 		sb.append("  i.database, i.source, i.type, i.subtype, i.name, i.search_name,");
 		sb.append("  i.description, i.url,");
@@ -41,7 +41,7 @@ public class IndexGroupAdapter {
 
 	public Cursor fetchById(Integer id) {
 		List<String> args = new ArrayList<String>();
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(selectStatement());
 		sb.append(" WHERE i.index_id = ?");
 		args.add(id.toString());
@@ -54,7 +54,7 @@ public class IndexGroupAdapter {
 
 	public Cursor fetchByUrl(String url) {
 		List<String> args = new ArrayList<String>();
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(selectStatement());
 		sb.append(" WHERE i.url = ?");
 		args.add(url);
@@ -67,7 +67,7 @@ public class IndexGroupAdapter {
 
 	public Cursor fetchByMatchUrl(String url) {
 		List<String> args = new ArrayList<String>();
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(selectStatement());
 		sb.append(" WHERE i.url LIKE ?");
 		args.add(url);
@@ -83,7 +83,7 @@ public class IndexGroupAdapter {
 			type = null;
 		}
 		List<String> args = new ArrayList<String>();
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(selectStatement());
 		String where = "WHERE";
 		if (type != null) {
@@ -108,7 +108,7 @@ public class IndexGroupAdapter {
 			type = null;
 		}
 		List<String> args = new ArrayList<String>();
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(selectStatement());
 		String where = "WHERE";
 		if (name != null) {
@@ -135,7 +135,7 @@ public class IndexGroupAdapter {
 
 	public Cursor fetchByCreatureType(String creatureType) {
 		List<String> args = new ArrayList<String>();
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(selectStatement());
 		sb.append(" WHERE i.type = 'creature'");
 		sb.append("  AND (i.subtype != 'npc'");
@@ -153,7 +153,7 @@ public class IndexGroupAdapter {
 
 	public Cursor fetchByFeatType(String featType) {
 		List<String> args = new ArrayList<String>();
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(selectStatement());
 		if (featType != null) {
 			sb.append("  INNER JOIN feat_type_index fti");
@@ -171,7 +171,7 @@ public class IndexGroupAdapter {
 
 	public Cursor fetchBySpellClass(String spellClass) {
 		List<String> args = new ArrayList<String>();
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(selectStatement(", sl.level, sl.name"));
 		sb.append("  INNER JOIN spell_list_index sl");
 		sb.append("   ON i.index_id = sl.index_id");
@@ -187,7 +187,7 @@ public class IndexGroupAdapter {
 
 	public Cursor fetchBySpellSource(String spellSource) {
 		List<String> args = new ArrayList<String>();
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(selectStatement());
 		sb.append(" WHERE i.spell_source = ?");
 		sb.append("  AND i.type = 'mythic_spell'");
@@ -201,7 +201,7 @@ public class IndexGroupAdapter {
 
 	public Cursor fetchByParentUrl(String parentUrl) {
 		List<String> args = new ArrayList<String>();
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(selectStatement());
 		sb.append("  INNER JOIN central_index p");
 		sb.append("   ON i.parent_id = p.section_id");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/MenuAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/MenuAdapter.java
@@ -22,7 +22,7 @@ public class MenuAdapter {
 
 	public Cursor fetchMenu() {
 		List<String> args = new ArrayList<String>();
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT menu_id, parent_menu_id, name, NULL AS parent_name, type, subtype, url, db, grouping, priority");
 		sb.append(" FROM menu");
 		sb.append(" WHERE parent_menu_id IS NULL");
@@ -35,7 +35,7 @@ public class MenuAdapter {
 	public Cursor fetchMenu(String parentMenuId) {
 		List<String> args = new ArrayList<String>();
 		args.add(parentMenuId);
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT m.menu_id, m.parent_menu_id, m.name, p.name AS parent_name,");
 		sb.append("  m.type, m.subtype, m.url, m.db, m.grouping, m.priority");
 		sb.append(" FROM menu m");
@@ -52,7 +52,7 @@ public class MenuAdapter {
 			MenuItem item = new MenuItem();
 			item.setId(getMenuId(cursor));
 			item.setName(getName(cursor));
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			sb.append("pfsrd://Menu/");
 			String parentName = getParentName(cursor);
 			if(parentName == null) {

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/SearchAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/SearchAdapter.java
@@ -23,7 +23,7 @@ public class SearchAdapter {
 	public Integer countSearchArticles(String constraint) {
 		constraint = constraint.replaceAll("[^A-Za-z0-9]", "").toLowerCase();
 		List<String> args = new ArrayList<String>();
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT count(DISTINCT i.index_id)");
 		sb.append(" FROM central_index i");
 		if (constraint != null) {
@@ -46,7 +46,7 @@ public class SearchAdapter {
 	public Cursor autocomplete(String constraint) {
 		constraint = constraint.replaceAll("[^A-Za-z0-9]", "").toLowerCase();
 		List<String> args = new ArrayList<String>();
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT i.section_id as _id,");
 		sb.append("  i.search_name AS " + SearchManager.SUGGEST_COLUMN_TEXT_1
 				+ ",");
@@ -72,7 +72,7 @@ public class SearchAdapter {
 	public Cursor getSingleSearchArticle(String constraint) {
 		constraint = constraint.replaceAll("[^A-Za-z0-9]", "").toLowerCase();
 		List<String> args = new ArrayList<String>();
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT DISTINCT i.section_id, i.database, i.name, i.type, i.subtype, i.url, i.parent_id, i.parent_name");
 		sb.append(" FROM central_index i");
 		sb.append("  INNER JOIN search_alternatives sa");
@@ -89,7 +89,7 @@ public class SearchAdapter {
 	public Cursor search(String constraint) {
 		constraint = constraint.replaceAll("[^A-Za-z0-9]", "").toLowerCase();
 		List<String> args = new ArrayList<String>();
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT DISTINCT i.section_id, i.database, i.name, i.type, i.subtype, i.url, i.parent_id, i.parent_name");
 		sb.append(" FROM central_index i");
 		sb.append("  INNER JOIN section_sort ss");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/SpellClassAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/SpellClassAdapter.java
@@ -21,7 +21,7 @@ public class SpellClassAdapter {
 
 	public Cursor fetchSpellClasses() {
 		List<String> args = new ArrayList<String>();
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT DISTINCT sli.name");
 		sb.append(" FROM spell_list_index sli");
 		sb.append("  INNER JOIN central_index ci");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/SpellListAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/SpellListAdapter.java
@@ -22,7 +22,7 @@ public class SpellListAdapter {
 	public Cursor fetchClassSpells(String class_name) {
 		List<String> args = new ArrayList<String>();
 		args.add(class_name);
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT i.name, i.url, sl.name, sl.level");
 		sb.append(" FROM spell_list_index sl");
 		sb.append("  INNER JOIN central_index i");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/UrlReferenceAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/UrlReferenceAdapter.java
@@ -22,7 +22,7 @@ public class UrlReferenceAdapter {
 	public String getDereferencedUrl(String url) {
 		List<String> args = new ArrayList<String>();
 		args.add(url);
-		StringBuffer sql = new StringBuffer();
+		StringBuilder sql = new StringBuilder();
 		sql.append("SELECT *");
 		sql.append(" FROM central_index");
 		sql.append(" WHERE url = ?");
@@ -43,7 +43,7 @@ public class UrlReferenceAdapter {
 	private String fetchUrlReference(String url) {
 		List<String> args = new ArrayList<String>();
 		args.add(url);
-		StringBuffer sql = new StringBuffer();
+		StringBuilder sql = new StringBuilder();
 		sql.append("SELECT c.url");
 		sql.append(" FROM central_index c");
 		sql.append("  INNER JOIN url_references u");
@@ -64,7 +64,7 @@ public class UrlReferenceAdapter {
 
 	public Cursor fetchBook(String source) {
 		List<String> args = new ArrayList<String>();
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT book_id, source, db");
 		sb.append(" FROM books");
 		sb.append(" WHERE source = ?");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/user/CollectionAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/user/CollectionAdapter.java
@@ -90,7 +90,7 @@ public class CollectionAdapter {
 	public Integer selectCollectionId(String name) {
 		List<String> args = new ArrayList<String>();
 		args.add(name);
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT collection_id");
 		sb.append(" FROM collections");
 		sb.append(" WHERE name = ?");
@@ -109,7 +109,7 @@ public class CollectionAdapter {
 	}
 
 	public Cursor fetchCollectionList() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT collection_id AS _id, name");
 		sb.append(" FROM collections");
 		String sql = sb.toString();
@@ -118,7 +118,7 @@ public class CollectionAdapter {
 
 	public Cursor fetchCollection(String collectionId) {
 		List<String> args = new ArrayList<String>();
-		StringBuffer sql = new StringBuffer();
+		StringBuilder sql = new StringBuilder();
 		sql.append("SELECT collections.*");
 		sql.append(" FROM collections");
 		sql.append(" WHERE collections.collection_id = ?");
@@ -128,7 +128,7 @@ public class CollectionAdapter {
 	}
 
 	public Cursor fetchFirstCollection() {
-		StringBuffer sql = new StringBuffer();
+		StringBuilder sql = new StringBuilder();
 		sql.append("SELECT collections.*");
 		sql.append(" FROM collections");
 		sql.append(" ORDER BY collection_id");
@@ -142,7 +142,7 @@ public class CollectionAdapter {
 		List<String> args = new ArrayList<String>();
 		args.add(Long.toString(collectionId));
 		args.add(url);
-		StringBuffer sql = new StringBuffer();
+		StringBuilder sql = new StringBuilder();
 		sql.append("SELECT 1 FROM collection_values");
 		sql.append(" WHERE collection_id = ?");
 		sql.append("  AND url = ?");
@@ -198,7 +198,7 @@ public class CollectionAdapter {
 	public Cursor fetchCollectionValues(String collectionName) {
 		List<String> args = new ArrayList<String>();
 		args.add(collectionName);
-		StringBuffer sql = new StringBuffer();
+		StringBuilder sql = new StringBuilder();
 		sql.append("SELECT cv.collection_entry_id, cv.name, cv.url");
 		sql.append(" FROM collection_values cv");
 		sql.append("  INNER JOIN collections");
@@ -211,7 +211,7 @@ public class CollectionAdapter {
 	public Cursor fetchCollectionValue(String collectionValueId) {
 		List<String> args = new ArrayList<String>();
 		args.add(collectionValueId);
-		StringBuffer sql = new StringBuffer();
+		StringBuilder sql = new StringBuilder();
 		sql.append("SELECT collection_entry_id, name, url");
 		sql.append(" FROM collection_values cv");
 		sql.append(" WHERE collection_entry_id = ?");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/user/HistoryAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/user/HistoryAdapter.java
@@ -36,7 +36,7 @@ public class HistoryAdapter {
 	public Integer selectHistoryId(String url) {
 		List<String> args = new ArrayList<String>();
 		args.add(url);
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("SELECT history_id");
 		sb.append(" FROM history");
 		sb.append(" WHERE url = ?");
@@ -56,7 +56,7 @@ public class HistoryAdapter {
 
 	public Cursor fetchHistory() {
 		List<String> args = new ArrayList<String>();
-		StringBuffer sql = new StringBuffer();
+		StringBuilder sql = new StringBuilder();
 		sql.append("SELECT history_id as _id, name, url");
 		sql.append(" FROM history");
 		sql.append(" ORDER BY history_id DESC");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/user/UserDbAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/user/UserDbAdapter.java
@@ -61,7 +61,7 @@ public class UserDbAdapter {
 
 	private Cursor fetchAllBookmarks() {
 		List<String> args = new ArrayList<String>();
-		StringBuffer sql = new StringBuffer();
+		StringBuilder sql = new StringBuilder();
 		sql.append("SELECT collection_entry_id, name, url");
 		sql.append(" FROM collection_values");
 		return database.rawQuery(sql.toString(),

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/user/UserDbHelper.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/user/UserDbHelper.java
@@ -31,7 +31,7 @@ public class UserDbHelper extends SQLiteOpenHelper {
 	}
 
 	private String createCollectionTable() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("CREATE TABLE collections(");
 		sb.append(" collection_id INTEGER PRIMARY KEY,");
 		sb.append(" name TEXT");
@@ -40,14 +40,14 @@ public class UserDbHelper extends SQLiteOpenHelper {
 	}
 
 	public String addDefaultCollection() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("INSERT INTO collections");
 		sb.append(" (name) VALUES ('default')");
 		return sb.toString();
 	}
 
 	private String createCollectionValuesTable() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("CREATE TABLE collection_values (");
 		sb.append(" collection_entry_id INTEGER PRIMARY KEY,");
 		sb.append(" collection_id INTEGER,");
@@ -58,7 +58,7 @@ public class UserDbHelper extends SQLiteOpenHelper {
 	}
 
 	private String createPsrdDbVersionTable() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("CREATE TABLE psrd_db_version (");
 		sb.append(" version INTEGER");
 		sb.append(")");
@@ -66,7 +66,7 @@ public class UserDbHelper extends SQLiteOpenHelper {
 	}
 
 	private String createHistoryTable() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("CREATE TABLE history (");
 		sb.append(" history_id INTEGER PRIMARY KEY,");
 		sb.append(" name TEXT,");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/list/CreatureListAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/list/CreatureListAdapter.java
@@ -62,7 +62,7 @@ public class CreatureListAdapter extends DisplayListAdapter {
 
 	private String createTypeLine(Cursor curs) {
 		// cd.size cd.alignment cd.creature_type (cd.creature_subtype)
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		String size = IndexGroupAdapter.IndexGroupUtils.getCreatureSize(c);
 		String space = "";
 		if (size != null) {

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/list/NpcListAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/list/NpcListAdapter.java
@@ -47,7 +47,7 @@ public class NpcListAdapter extends DisplayListAdapter {
 
 	private String createTypeLine(Cursor curs) {
 		// cd.size cd.alignment cd.creature_type (cd.creature_subtype)
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		String space = "";
 		String size = IndexGroupAdapter.IndexGroupUtils.getCreatureSize(c);
 		if (size != null) {

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/list/SearchListAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/list/SearchListAdapter.java
@@ -32,7 +32,7 @@ public class SearchListAdapter extends DisplayListAdapter {
 		TextView parent_name = (TextView) V.findViewById(R.id.search_list_parent);
 		parent_name.setText("From: " + SearchAdapter.SearchUtils.getParentName(c));
 		TextView type = (TextView) V.findViewById(R.id.search_list_misc);
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		String sectionType = SearchAdapter.SearchUtils.getType(c);
 		String sectionSubtype = SearchAdapter.SearchUtils.getSubtype(c);
 		sb.append("(");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/list/SkillListItem.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/list/SkillListItem.java
@@ -43,7 +43,7 @@ public class SkillListItem extends BaseListItem {
 	}
 
 	public static String buildQualitiesDisplay(boolean armorCheckPenalty, boolean trainedOnly) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		String spacer = " (";
 		String end = "";
 		if (armorCheckPenalty) {

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/list/SpellListItem.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/list/SpellListItem.java
@@ -55,7 +55,7 @@ public class SpellListItem extends BaseListItem {
 	}
 
 	public static String buildSchoolLine(String school, String subschool, String descriptor) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(school);
 		if (subschool != null) {
 			sb.append(" (");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/preference/FilterPreferenceManager.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/preference/FilterPreferenceManager.java
@@ -18,7 +18,7 @@ public class FilterPreferenceManager {
 
 	public static String getSourceFilter(Context context, List<String> args,
 			String conjunction, String tableName) {
-		StringBuffer filter = new StringBuffer();
+		StringBuilder filter = new StringBuilder();
 		ArrayList<String> sourceList = new ArrayList<String>();
 
 		// The default values must be set here to bypass a bug in Android

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/AbilityRenderer.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/AbilityRenderer.java
@@ -25,7 +25,7 @@ public class AbilityRenderer extends HtmlRenderer {
 	public String abilityName(String name, Integer sectionId) {
 		Cursor cursor = bookDbAdapter.getAbilityAdapter().getAbilityTypes(sectionId);
 		try {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			sb.append(name);
 			boolean fields = false;
 			boolean has_next = cursor.moveToFirst();

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/AfflictionRenderer.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/AfflictionRenderer.java
@@ -23,7 +23,7 @@ public class AfflictionRenderer extends StatBlockRenderer {
 		// 0:contracted, 1:save, 2:onset, 3:frequency, 4:effect,
 		// 5:initial_effect, 6:secondary_effect, 7:cure
 		try {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			boolean has_next = cursor.moveToFirst();
 			if (has_next) {
 				String contracted = AfflictionAdapter.AfflictionUtils.getContracted(cursor);

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/AnimalCompanionRenderer.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/AnimalCompanionRenderer.java
@@ -17,7 +17,7 @@ public class AnimalCompanionRenderer extends StatBlockRenderer {
 		Cursor cursor = bookDbAdapter.getAnimalCompanionAdapter()
 				.getAnimalCompanionDetails(sectionId);
 		try {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			boolean has_next = cursor.moveToFirst();
 			if (has_next) {
 				String level = AnimalCompanionAdapter.AnimalCompanionUtils
@@ -41,7 +41,7 @@ public class AnimalCompanionRenderer extends StatBlockRenderer {
 		Cursor cursor = bookDbAdapter.getAnimalCompanionAdapter()
 				.getAnimalCompanionDetails(sectionId);
 		try {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			boolean has_next = cursor.moveToFirst();
 			if (has_next) {
 				sb.append(addField("Size",

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/ArmyRenderer.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/ArmyRenderer.java
@@ -36,7 +36,7 @@ public class ArmyRenderer extends StatBlockRenderer {
 		Cursor cursor = bookDbAdapter.getArmyAdapter()
 				.getArmyDetails(sectionId);
 		try {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			boolean has_next = cursor.moveToFirst();
 			if (has_next) {
 				String xp = ArmyAdapter.ArmyUtils.getXp(cursor);

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/ClassRenderer.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/ClassRenderer.java
@@ -19,7 +19,7 @@ public class ClassRenderer extends HtmlRenderer {
 
 	@Override
 	public String renderFooter() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		Cursor cursor = bookDbAdapter.getClassAdapter().fetchClassDetails(sectionId);
 		try {
 			sb.append("<B>Source: </B>");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/CreatureRenderer.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/CreatureRenderer.java
@@ -39,7 +39,7 @@ public class CreatureRenderer extends StatBlockRenderer {
 		Cursor curs = bookDbAdapter.getCreatureAdapter().getCreatureDetails(
 				sectionId);
 		try {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			boolean has_next = curs.moveToFirst();
 			if (has_next) {
 				sb.append(renderCreatureHeader(curs, desc, source, newUri, top));
@@ -61,7 +61,7 @@ public class CreatureRenderer extends StatBlockRenderer {
 
 	private String renderCreatureHeader(Cursor cursor, String desc,
 			String source, String newUri, boolean top) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		if (desc != null) {
 			sb.append("<p>");
 			sb.append(desc);
@@ -104,7 +104,7 @@ public class CreatureRenderer extends StatBlockRenderer {
 	}
 
 	private String renderCreatureDefense(Cursor cursor) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(renderStatBlockBreaker("Defense"));
 		sb.append(addField("Natural Armor",
 				CreatureAdapter.CreatureUtils.getNaturalArmor(cursor), false));
@@ -140,7 +140,7 @@ public class CreatureRenderer extends StatBlockRenderer {
 	}
 
 	private String renderCreatureOffense(Cursor cursor) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(renderStatBlockBreaker("Offense"));
 		sb.append(addField("Speed",
 				CreatureAdapter.CreatureUtils.getSpeed(cursor)));
@@ -168,7 +168,7 @@ public class CreatureRenderer extends StatBlockRenderer {
 				sectionId);
 		// 0:name, 1:body
 		try {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			boolean has_next = cursor.moveToFirst();
 			while (has_next) {
 				String name = capitalizeString(CreatureAdapter.CreatureSpellsUtils
@@ -184,7 +184,7 @@ public class CreatureRenderer extends StatBlockRenderer {
 	}
 
 	private String renderCreatureStatistics(Cursor cursor) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(renderStatBlockBreaker("Statistics"));
 		sb.append(addField("Str",
 				CreatureAdapter.CreatureUtils.getStrength(cursor), false));
@@ -232,7 +232,7 @@ public class CreatureRenderer extends StatBlockRenderer {
 	}
 
 	private String renderCreatureEcology(Cursor cursor) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		// 47:environment, 48:organization, 49:treasure
 		sb.append(renderStatBlockBreaker("Ecology"));
 		sb.append(addField("Environment",

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/EmbedRenderer.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/EmbedRenderer.java
@@ -42,7 +42,7 @@ public class EmbedRenderer extends HtmlRenderer {
 
 	@Override
 	public String renderBody() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		if ("spell_list".equals(this.subtype)) {
 			sb.append(renderSpellList());
 		}
@@ -50,7 +50,7 @@ public class EmbedRenderer extends HtmlRenderer {
 	}
 
 	public String renderSpellList() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		SpellListAdapter sla = dbWrangler.getIndexDbAdapter()
 				.getSpellListAdapter();
 		Cursor cursor = sla.fetchClassSpells(capitalizeString(this.desc));

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/FeatRenderer.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/FeatRenderer.java
@@ -16,7 +16,7 @@ public class FeatRenderer extends HtmlRenderer {
 
 	@Override
 	public String renderDetails() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("<B>");
 		sb.append(bookDbAdapter.getFeatAdapter().renderFeatTypeDescription(sectionId));
 		sb.append("</B><BR>\n");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/HauntRenderer.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/HauntRenderer.java
@@ -34,7 +34,7 @@ public class HauntRenderer extends StatBlockRenderer {
 	public String renderDetails() {
 		Cursor cursor = bookDbAdapter.getHauntAdapter().getHauntDetails(sectionId);
 		try {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			boolean has_next = cursor.moveToFirst();
 			if (has_next) {
 				String cr = HauntAdapter.HauntUtils.getCr(cursor);

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/HtmlRenderer.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/HtmlRenderer.java
@@ -52,7 +52,7 @@ public abstract class HtmlRenderer {
 		this.image = FullSectionAdapter.SectionUtils.getImage(cursor);
 		this.alt = FullSectionAdapter.SectionUtils.getAlt(cursor);
 		localSetValues();
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		if (suppressTitle == false) {
 			sb.append(renderTitle());
 		}
@@ -69,7 +69,7 @@ public abstract class HtmlRenderer {
 	}
 
 	public String renderImage() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		if (image != null) {
 			if (isTablet) {
 				sb.append("<img style='float: left' src='file:///android_asset/");
@@ -89,7 +89,7 @@ public abstract class HtmlRenderer {
 	}
 
 	public String renderDescription() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		if (desc != null) {
 			sb.append("<p>");
 			sb.append(desc);
@@ -99,7 +99,7 @@ public abstract class HtmlRenderer {
 	}
 
 	public String renderBody() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		if (body != null) {
 			int index = body.indexOf("img src=");
 			if (index > 0) {
@@ -123,7 +123,7 @@ public abstract class HtmlRenderer {
 	}
 
 	protected String displayLine(List<String> elements) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		boolean space = false;
 		for (int i = 0; i < elements.size(); i++) {
 			String elem = elements.get(i);
@@ -146,7 +146,7 @@ public abstract class HtmlRenderer {
 	}
 
 	public String addField(String field, String value, boolean lineEnd) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		if (value != null) {
 			sb.append(fieldTitle(field));
 			sb.append(value);
@@ -165,7 +165,7 @@ public abstract class HtmlRenderer {
 			return "";
 		}
 
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		String[] tags = getDepthTag(depth);
 		if (title != null) {
 			sb.append("\n");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/ItemRenderer.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/ItemRenderer.java
@@ -20,7 +20,7 @@ public class ItemRenderer extends StatBlockRenderer {
 
 	@Override
 	public String renderDetails() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(renderItemDetails());
 		return sb.toString();
 	}
@@ -29,7 +29,7 @@ public class ItemRenderer extends StatBlockRenderer {
 		Cursor cursor = bookDbAdapter.getItemAdapter()
 				.getItemDetails(sectionId);
 		try {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			boolean has_next = cursor.moveToFirst();
 			if (has_next) {
 				sb.append(addField("Aura",
@@ -57,8 +57,8 @@ public class ItemRenderer extends StatBlockRenderer {
 	public String renderItemMisc() {
 		Cursor cursor = bookDbAdapter.getItemAdapter().getItemMisc(sectionId);
 		try {
-			StringBuffer sb = new StringBuffer();
-			StringBuffer titleSb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
+			StringBuilder titleSb = new StringBuilder();
 			boolean has_next = cursor.moveToFirst();
 			String lastSection = "";
 			while (has_next) {

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/KingdomResourceRenderer.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/KingdomResourceRenderer.java
@@ -55,7 +55,7 @@ public class KingdomResourceRenderer extends StatBlockRenderer {
 		Cursor cursor = bookDbAdapter.getKingdomResourceAdapter()
 				.getKingdomResourceDetails(sectionId);
 		try {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			boolean has_next = cursor.moveToFirst();
 			if (has_next) {
 				if (top) {

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/LinkRenderer.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/LinkRenderer.java
@@ -86,7 +86,7 @@ public class LinkRenderer extends HtmlRenderer {
 		if (!exists) {
 			return "";
 		}
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		if (render) {
 			sb.append("<a href='");
 			sb.append(linkUrl);

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/MythicSpellRenderer.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/MythicSpellRenderer.java
@@ -90,7 +90,7 @@ public class MythicSpellRenderer extends HtmlRenderer {
 		if (!exists) {
 			return "";
 		}
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		HashMap<Integer, Integer> depthMap = new HashMap<Integer, Integer>();
 		int localdepth = depth;
 		boolean showTitle = true;

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/ResourceRenderer.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/ResourceRenderer.java
@@ -34,7 +34,7 @@ public class ResourceRenderer extends StatBlockRenderer {
 		Cursor cursor = bookDbAdapter.getResourceAdapter().getResourceDetails(
 				sectionId);
 		try {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			boolean has_next = cursor.moveToFirst();
 			if (has_next) {
 				sb.append(addField("Wage",
@@ -52,7 +52,7 @@ public class ResourceRenderer extends StatBlockRenderer {
 		Cursor cursor = bookDbAdapter.getResourceAdapter().getResourceDetails(
 				sectionId);
 		try {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			boolean has_next = cursor.moveToFirst();
 			if (has_next) {
 				sb.append(addField("Create",
@@ -70,7 +70,7 @@ public class ResourceRenderer extends StatBlockRenderer {
 		Cursor cursor = bookDbAdapter.getResourceAdapter().getResourceDetails(
 				sectionId);
 		try {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			boolean has_next = cursor.moveToFirst();
 			if (has_next) {
 				sb.append(addField("Create",
@@ -88,7 +88,7 @@ public class ResourceRenderer extends StatBlockRenderer {
 		Cursor cursor = bookDbAdapter.getResourceAdapter().getResourceDetails(
 				sectionId);
 		try {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			boolean has_next = cursor.moveToFirst();
 			if (has_next) {
 				sb.append(addField("Earnings",

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/SettlementRenderer.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/SettlementRenderer.java
@@ -21,7 +21,7 @@ public class SettlementRenderer extends StatBlockRenderer {
 	public String renderDetails() {
 		Cursor cursor = bookDbAdapter.getSettlementAdapter().getSettlementDetails(sectionId);
 		try {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			boolean has_next = cursor.moveToFirst();
 			if (has_next) {
 				String align = SettlementAdapter.SettlementUtils.getAlignment(cursor);

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/SkillRenderer.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/SkillRenderer.java
@@ -19,7 +19,7 @@ public class SkillRenderer extends HtmlRenderer {
 
 	@Override
 	public String renderDetails() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(renderSkillDetails(sectionId));
 		sb.append("<B>Source: </B>");
 		sb.append(source);
@@ -30,7 +30,7 @@ public class SkillRenderer extends HtmlRenderer {
 	public String renderSkillDetails(Integer sectionId) {
 		Cursor cursor = bookDbAdapter.getSkillAdapter().fetchSkillAttr(sectionId);
 		try {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			boolean has_next = cursor.moveToFirst();
 			if (has_next) {
 				sb.append("<H2>(");

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/SpellRenderer.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/SpellRenderer.java
@@ -32,7 +32,7 @@ public class SpellRenderer extends HtmlRenderer {
 
 	@Override
 	public String renderDetails() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append(renderSpellDetails(sectionId));
 		sb.append("<B>Source: </B>");
 		sb.append(source);
@@ -48,7 +48,7 @@ public class SpellRenderer extends HtmlRenderer {
 	private String renderSpellLevels(Integer sectionId) {
 		Cursor cursor = bookDbAdapter.getSpellListAdapter().getSpellLists(
 				sectionId);
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		try {
 			boolean has_next = cursor.moveToFirst();
 			String semi = "";
@@ -71,7 +71,7 @@ public class SpellRenderer extends HtmlRenderer {
 		Cursor cursor = bookDbAdapter.getSpellDetailAdapter()
 				.fetchSpellDetails(sectionId);
 		try {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			boolean has_next = cursor.moveToFirst();
 			if (has_next) {
 				String school = SpellDetailAdapter.SpellDetailUtils
@@ -141,7 +141,7 @@ public class SpellRenderer extends HtmlRenderer {
 		Cursor cursor = bookDbAdapter.getSpellEffectAdapter()
 				.fetchSpellEffects(sectionId);
 		try {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			boolean has_next = cursor.moveToFirst();
 			while (has_next) {
 				String name = SpellEffectAdapter.SpellEffectUtils
@@ -164,7 +164,7 @@ public class SpellRenderer extends HtmlRenderer {
 
 	@Override
 	public String renderFooter() {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		Cursor cursor = dbWrangler.getIndexDbAdapter().getIndexGroupAdapter()
 				.fetchBySpellSource(name);
 		try {

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/StatBlockRenderer.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/StatBlockRenderer.java
@@ -6,7 +6,7 @@ public abstract class StatBlockRenderer extends HtmlRenderer {
 			return "";
 		}
 
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		if (title != null) {
 			sb.append("\n<p class='stat-block-title'><a href='");
 			sb.append(newUri);
@@ -18,7 +18,7 @@ public abstract class StatBlockRenderer extends HtmlRenderer {
 	}
 
 	public String renderStatBlockBreaker(String title) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		if (title != null) {
 			sb.append("\n<p class='stat-block-breaker'>");
 			sb.append(title);

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/TalentRenderer.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/TalentRenderer.java
@@ -21,7 +21,7 @@ public class TalentRenderer extends StatBlockRenderer {
 	public String renderDetails() {
 		Cursor cursor = bookDbAdapter.getTalentAdapter().getTalentDetails(sectionId);
 		try {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			boolean has_next = cursor.moveToFirst();
 			if (has_next) {
 				sb.append(addField("Element", TalentAdapter.TalentUtils.getElement(cursor), false));

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/TrapRenderer.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/TrapRenderer.java
@@ -34,7 +34,7 @@ public class TrapRenderer extends StatBlockRenderer {
 	public String abilityName(String name, Integer sectionId) {
 		Cursor cursor = bookDbAdapter.getAbilityAdapter().getAbilityTypes(sectionId);
 		try {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			sb.append(name);
 			boolean fields = false;
 			boolean has_next = cursor.moveToFirst();
@@ -69,7 +69,7 @@ public class TrapRenderer extends StatBlockRenderer {
 	public String renderDetails() {
 		Cursor cursor = bookDbAdapter.getTrapAdapter().getTrapDetails(sectionId);
 		try {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			boolean has_next = cursor.moveToFirst();
 			if (has_next) {
 				String cr = TrapAdapter.TrapUtils.getCr(cursor);

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/VehicleRenderer.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/VehicleRenderer.java
@@ -21,7 +21,7 @@ public class VehicleRenderer extends StatBlockRenderer {
 	public String renderDetails() {
 		Cursor cursor = bookDbAdapter.getVehicleAdapter().getVehicleDetails(sectionId);
 		try {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			boolean has_next = cursor.moveToFirst();
 			if (has_next) {
 				String size = VehicleAdapter.VehicleUtils.getSize(cursor);

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/utils/UrlAliaser.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/utils/UrlAliaser.java
@@ -30,7 +30,7 @@ public class UrlAliaser {
 	protected static String aliasRulesUrl(String[] parts) {
 		// pfsrd://PFSRD/Rules Ultimate Combat/Class Archetypes/Class Archetypes
 		String book = parts[3].substring(6);
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("pfsrd://");
 		sb.append(book);
 		sb.append("/Rules");
@@ -62,7 +62,7 @@ public class UrlAliaser {
 	}
 
 	protected static String createTestUrl(String[] parts, int sub) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		sb.append("pfsrd://%");
 		for (int i = 3; i < parts.length - sub; i++) {
 			sb.append("/");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1149 - “Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149
Please let me know if you have any questions.
Ayman Abdelghany.