### PR TITLE
Utility classes should not have public constructors

### DIFF
--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/AbilityAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/AbilityAdapter.java
@@ -29,6 +29,9 @@ public class AbilityAdapter {
 	}
 
 	public static class AbilityUtils {
+		private AbilityUtils() {
+		}
+
 		public static String getAbilityType(Cursor cursor) {
 			return cursor.getString(0);
 		}

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/AfflictionAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/AfflictionAdapter.java
@@ -30,6 +30,9 @@ public class AfflictionAdapter {
 	}
 
 	public static class AfflictionUtils {
+		private AfflictionUtils() {
+		}
+
 		public static String getContracted(Cursor cursor) { return cursor.getString(0); }
 		public static String getAddiction(Cursor cursor) { return cursor.getString(1); }
 		public static String getSave(Cursor cursor) { return cursor.getString(2); }

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/AnimalCompanionAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/AnimalCompanionAdapter.java
@@ -31,6 +31,9 @@ public class AnimalCompanionAdapter {
 	}
 
 	public static class AnimalCompanionUtils {
+		private AnimalCompanionUtils() {
+		}
+
 		public static String getAc(Cursor cursor) {
 			return cursor.getString(0);
 		}

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/ArmyAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/ArmyAdapter.java
@@ -31,6 +31,9 @@ public class ArmyAdapter {
 	}
 
 	public static class ArmyUtils {
+		private ArmyUtils() {
+		}
+
 		public static String getXp(Cursor cursor) {
 			return cursor.getString(0);
 		}

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/ClassAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/ClassAdapter.java
@@ -29,6 +29,9 @@ public class ClassAdapter {
 	}
 
 	public static class ClassUtils {
+		private ClassUtils() {
+		}
+
 		public static String getAlignment(Cursor cursor) {
 			return cursor.getString(0);
 		}

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/CreatureAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/CreatureAdapter.java
@@ -37,6 +37,9 @@ public class CreatureAdapter {
 	}
 
 	public static class CreatureUtils {
+		private CreatureUtils() {
+		}
+
 		public static String getSex(Cursor cursor) {
 			return cursor.getString(0);
 		}
@@ -266,6 +269,9 @@ public class CreatureAdapter {
 	}
 
 	public static class CreatureSpellsUtils {
+		private CreatureSpellsUtils() {
+		}
+
 		public static String getName(Cursor cursor) {
 			return cursor.getString(0);
 		}

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/FeatAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/FeatAdapter.java
@@ -57,6 +57,9 @@ public class FeatAdapter {
 	}
 
 	public static class FeatTypeUtils {
+		private FeatTypeUtils() {
+		}
+
 		public static String getFeatType(Cursor cursor) {
 			return cursor.getString(0);
 		}

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/FullSectionAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/FullSectionAdapter.java
@@ -32,6 +32,9 @@ public class FullSectionAdapter {
 	}
 
 	public static class SectionUtils {
+		private SectionUtils() {
+		}
+
 		public static Integer getSectionId(Cursor cursor) {
 			return cursor.getInt(0);
 		}

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/HauntAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/HauntAdapter.java
@@ -29,6 +29,9 @@ public class HauntAdapter {
 	}
 
 	public static class HauntUtils {
+		private HauntUtils() {
+		}
+
 		public static String getCr(Cursor cursor) {
 			return cursor.getString(0);
 		}

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/ItemAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/ItemAdapter.java
@@ -29,6 +29,9 @@ public class ItemAdapter {
 	}
 
 	public static class ItemUtils {
+		private ItemUtils() {
+		}
+
 		public static String getAura(Cursor cursor) {
 			return cursor.getString(0);
 		}
@@ -63,6 +66,9 @@ public class ItemAdapter {
 	}
 
 	public static class ItemMiscUtils {
+		private ItemMiscUtils() {
+		}
+
 		public static String getField(Cursor cursor) {
 			return cursor.getString(0);
 		}

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/KingdomResourceAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/KingdomResourceAdapter.java
@@ -31,6 +31,9 @@ public class KingdomResourceAdapter {
 	}
 
 	public static class KingdomResourceUtils {
+		private KingdomResourceUtils() {
+		}
+
 		public static String getBp(Cursor cursor) {
 			return cursor.getString(0);
 		}

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/LinkAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/LinkAdapter.java
@@ -30,6 +30,9 @@ public class LinkAdapter {
 	}
 
 	public static class LinkUtils {
+		private LinkUtils() {
+		}
+
 		public static Integer getSectionId(Cursor cursor) {
 			return cursor.getInt(0);
 		}

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/MythicSpellDetailAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/MythicSpellDetailAdapter.java
@@ -40,6 +40,9 @@ public class MythicSpellDetailAdapter {
 	}
 
 	public static class MythicSpellDetailUtils {
+		private MythicSpellDetailUtils() {
+		}
+
 		public static Integer getSectionId(Cursor cursor) {
 			return cursor.getInt(0);
 		}

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/ResourceAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/ResourceAdapter.java
@@ -30,6 +30,9 @@ public class ResourceAdapter {
 	}
 
 	public static class ResourceUtils {
+		private ResourceUtils() {
+		}
+
 		public static String getBenefit(Cursor cursor) {
 			return cursor.getString(0);
 		}

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SectionAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SectionAdapter.java
@@ -109,6 +109,9 @@ public class SectionAdapter {
 	}
 
 	public static class SectionUtils {
+		private SectionUtils() {
+		}
+
 		public static Integer getSectionId(Cursor cursor) {
 			return cursor.getInt(0);
 		}

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SectionIndexGroupAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SectionIndexGroupAdapter.java
@@ -33,6 +33,9 @@ public class SectionIndexGroupAdapter {
 	}
 
 	public static class SectionGroupIndexUtils {
+		private SectionGroupIndexUtils() {
+		}
+
 		public static Integer getSectionId(Cursor cursor) {
 			return cursor.getInt(0);
 		}

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SettlementAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SettlementAdapter.java
@@ -32,6 +32,9 @@ public class SettlementAdapter {
 	}
 
 	public static class SettlementUtils {
+		private SettlementUtils() {
+		}
+
 		public static String getAlignment(Cursor cursor) {
 			return cursor.getString(0);
 		}

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SkillAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SkillAdapter.java
@@ -29,6 +29,9 @@ public class SkillAdapter {
 	}
 
 	public static class SkillUtils {
+		private SkillUtils() {
+		}
+
 		public static String getAttribute(Cursor cursor) {
 			return cursor.getString(0);
 		}

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SpellComponentAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SpellComponentAdapter.java
@@ -29,6 +29,9 @@ public class SpellComponentAdapter {
 	}
 
 	public static class SpellComponentUtils {
+		private SpellComponentUtils() {
+		}
+
 		public static String getComponentType(Cursor cursor) {
 			return cursor.getString(0);
 		}

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SpellDescriptorAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SpellDescriptorAdapter.java
@@ -29,6 +29,9 @@ public class SpellDescriptorAdapter {
 	}
 
 	public static class SpellDescriptorUtils {
+		private SpellDescriptorUtils() {
+		}
+
 		public static String getDescriptor(Cursor cursor) {
 			return cursor.getString(0);
 		}

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SpellDetailAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SpellDetailAdapter.java
@@ -30,6 +30,9 @@ public class SpellDetailAdapter {
 	}
 
 	public static class SpellDetailUtils {
+		private SpellDetailUtils() {
+		}
+
 		public static String getSchool(Cursor cursor) {
 			return cursor.getString(0);
 		}

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SpellEffectAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SpellEffectAdapter.java
@@ -29,6 +29,9 @@ public class SpellEffectAdapter {
 	}
 
 	public static class SpellEffectUtils {
+		private SpellEffectUtils() {
+		}
+
 		public static String getName(Cursor cursor) {
 			return cursor.getString(0);
 		}

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SpellListAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SpellListAdapter.java
@@ -29,6 +29,9 @@ public class SpellListAdapter {
 	}
 
 	public static class SpellListUtils {
+		private SpellListUtils() {
+		}
+
 		public static Integer getLevel(Cursor cursor) {
 			return cursor.getInt(0);
 		}

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SpellSubschoolAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/SpellSubschoolAdapter.java
@@ -29,6 +29,9 @@ public class SpellSubschoolAdapter {
 	}
 
 	public static class SpellSubschoolUtils {
+		private SpellSubschoolUtils() {
+		}
+
 		public static String getSubschool(Cursor cursor) {
 			return cursor.getString(0);
 		}

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/TalentAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/TalentAdapter.java
@@ -30,6 +30,9 @@ public class TalentAdapter {
 	}
 
 	public static class TalentUtils {
+		private TalentUtils() {
+		}
+
 		public static String getElement(Cursor cursor) { return cursor.getString(0); }
 		public static String getTalentType(Cursor cursor) { return cursor.getString(1); }
 		public static String getBlastType(Cursor cursor) { return cursor.getString(2); }

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/TrapAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/TrapAdapter.java
@@ -29,6 +29,9 @@ public class TrapAdapter {
 	}
 
 	public static class TrapUtils {
+		private TrapUtils() {
+		}
+
 		public static String getCr(Cursor cursor) {
 			return cursor.getString(0);
 		}

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/VehicleAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/book/VehicleAdapter.java
@@ -32,6 +32,9 @@ public class VehicleAdapter {
 	}
 
 	public static class VehicleUtils {
+		private VehicleUtils() {
+		}
+
 		public static String getSize(Cursor cursor) {
 			return cursor.getString(0);
 		}

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/BooksAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/BooksAdapter.java
@@ -33,6 +33,9 @@ public class BooksAdapter {
 	}
 
 	public static class BookUtils {
+		private BookUtils() {
+		}
+
 		public static String getBookDb(Cursor cursor) {
 			boolean hasnext = cursor.moveToFirst();
 			if(hasnext) {

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/CountAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/CountAdapter.java
@@ -58,6 +58,9 @@ public class CountAdapter {
 	}
 
 	public static class CountUtils {
+		private CountUtils() {
+		}
+
 		public static Integer getCount(Cursor cursor) {
 			return cursor.getInt(0);
 		}

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/CreatureTypeAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/CreatureTypeAdapter.java
@@ -32,6 +32,9 @@ public class CreatureTypeAdapter {
 	}
 	
 	public static class CreatureTypeUtils {
+		private CreatureTypeUtils() {
+		}
+
 		public static String getCreatureType(Cursor cursor) {
 			return cursor.getString(0);
 		}

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/FeatTypeAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/FeatTypeAdapter.java
@@ -33,6 +33,9 @@ public class FeatTypeAdapter {
 	}
 	
 	public static class FeatTypeUtils {
+		private FeatTypeUtils() {
+		}
+
 		public static String getFeatType(Cursor cursor) {
 			return cursor.getString(0);
 		}

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/IndexGroupAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/IndexGroupAdapter.java
@@ -216,6 +216,9 @@ public class IndexGroupAdapter {
 	}
 
 	public static class IndexGroupUtils {
+		private IndexGroupUtils() {
+		}
+
 		public static Integer getIndexId(Cursor cursor) {
 			return cursor.getInt(0);
 		}

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/MenuAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/MenuAdapter.java
@@ -48,6 +48,9 @@ public class MenuAdapter {
 	}
 	
 	public static class MenuUtils {
+		private MenuUtils() {
+		}
+
 		public static MenuItem genMenuItem(Cursor cursor) {
 			MenuItem item = new MenuItem();
 			item.setId(getMenuId(cursor));

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/SearchAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/SearchAdapter.java
@@ -108,6 +108,9 @@ public class SearchAdapter {
 	}
 
 	public static class SearchUtils {
+		private SearchUtils() {
+		}
+
 		public static Integer getSectionId(Cursor cursor) {
 			return cursor.getInt(0);
 		}

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/SpellClassAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/SpellClassAdapter.java
@@ -34,6 +34,9 @@ public class SpellClassAdapter {
 	}
 	
 	public static class SpellListUtils {
+		private SpellListUtils() {
+		}
+
 		public static String getName(Cursor cursor) {
 			return cursor.getString(0);
 		}

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/SpellListAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/SpellListAdapter.java
@@ -35,6 +35,9 @@ public class SpellListAdapter {
 	}
 
 	public static class SpellListUtils {
+		private SpellListUtils() {
+		}
+
 		public static String getSpellName(Cursor cursor) {
 			return cursor.getString(0);
 		}

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/UrlReferenceAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/index/UrlReferenceAdapter.java
@@ -76,6 +76,9 @@ public class UrlReferenceAdapter {
 	}
 
 	public static class BookUtils {
+		private BookUtils() {
+		}
+
 		public static String getBookDb(Cursor cursor) {
 			boolean hasnext = cursor.moveToFirst();
 			if (hasnext) {

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/user/HistoryAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/user/HistoryAdapter.java
@@ -66,6 +66,9 @@ public class HistoryAdapter {
 	}
 
 	public static class HistoryUtils {
+		private HistoryUtils() {
+		}
+
 		public static Integer getHistoryId(Cursor cursor) {
 			return cursor.getInt(0);
 		}

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/preference/FilterPreferenceManager.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/preference/FilterPreferenceManager.java
@@ -11,8 +11,11 @@ import android.preference.PreferenceManager;
 
 public class FilterPreferenceManager {
 
+	private FilterPreferenceManager() {
+	}
+
 	public static String getSourceFilter(Context context, List<String> args,
-			String conjunction) {
+					String conjunction) {
 		return getSourceFilter(context, args, conjunction, null);
 	}
 

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/utils/AvailableSpaceHandler.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/utils/AvailableSpaceHandler.java
@@ -28,6 +28,9 @@ public class AvailableSpaceHandler {
 	 */
 	public final static long SIZE_GB = SIZE_KB * SIZE_KB * SIZE_KB;
 
+	private AvailableSpaceHandler() {
+	}
+
 	/**
 	 * @return Number of bytes available on external storage
 	 */

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/utils/UrlAliaser.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/utils/UrlAliaser.java
@@ -8,6 +8,9 @@ import android.database.Cursor;
 
 public class UrlAliaser {
 
+	private UrlAliaser() {
+	}
+
 	public static String aliasUrl(DbWrangler dbWrangler, String url) {
 		String[] parts = url.split("\\/");
 		if (parts[2].equals("PFSRD")) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.
