### PR TITLE
Literal boolean values should not be used in condition expressions

### DIFF
--- a/app/src/main/java/org/evilsoft/pathfinder/reference/HtmlRenderFarm.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/HtmlRenderFarm.java
@@ -212,7 +212,7 @@ public class HtmlRenderFarm {
 			return true;
 		}
 		HtmlRenderer prev = renderPath.get(renderPath.size() - 1);
-		return prev.suppressNextTitle == true;
+		return prev.suppressNextTitle;
 	}
 
 	public String renderFooter() {

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/SearchProvider.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/SearchProvider.java
@@ -19,7 +19,7 @@ public class SearchProvider extends ContentProvider {
 	}
 
 	public boolean initializeDatabase() {
-		if (dbWrangler != null && dbWrangler.isClosed() == false) {
+		if (dbWrangler != null && !dbWrangler.isClosed()) {
 			return true;
 		}
 		boolean cont = true;

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/api/AbstractContentProvider.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/api/AbstractContentProvider.java
@@ -45,7 +45,7 @@ public abstract class AbstractContentProvider extends ContentProvider {
 	}
 
 	public boolean initializeDatabase() {
-		if (dbWrangler != null && dbWrangler.isClosed() == false) {
+		if (dbWrangler != null && !dbWrangler.isClosed()) {
 			return true;
 		}
 		boolean cont = true;

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/BaseDbHelper.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/BaseDbHelper.java
@@ -75,7 +75,7 @@ public abstract class BaseDbHelper extends SQLiteOpenHelper {
 		}
 		if (retry) {
 			boolean dbExists = checkDatabase();
-			if (dbExists == false) {
+			if (!dbExists) {
 				buildDatabase(false);
 			}
 		}

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/db/DbWrangler.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/db/DbWrangler.java
@@ -53,7 +53,7 @@ public class DbWrangler {
 		}
 		checkIndexDb(current);
 		checkBookDbs(current);
-		if (current == false) {
+		if (!current) {
 			SharedPreferences.Editor editor = settings.edit();
 			editor.putInt(CURRENT_VERSION, VERSION);
 			editor.commit();

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/preference/FilterPreferenceManager.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/preference/FilterPreferenceManager.java
@@ -28,58 +28,58 @@ public class FilterPreferenceManager {
 		SharedPreferences preferences = PreferenceManager
 				.getDefaultSharedPreferences(context);
 
-		if (preferences.getBoolean("source_APG", true) == false) {
+		if (!preferences.getBoolean("source_APG", true)) {
 			sourceList.add("Advanced Player's Guide");
 		}
-		if (preferences.getBoolean("source_ACG", true) == false) {
+		if (!preferences.getBoolean("source_ACG", true)) {
 			sourceList.add("Advanced Class Guide");
 		}
-		if (preferences.getBoolean("source_ARG", true) == false) {
+		if (!preferences.getBoolean("source_ARG", true)) {
 			sourceList.add("Advanced Race Guide");
 		}
-		if (preferences.getBoolean("source_UCA", true) == false) {
+		if (!preferences.getBoolean("source_UCA", true)) {
 			sourceList.add("Ultimate Campaign");
 		}
-		if (preferences.getBoolean("source_UC", true) == false) {
+		if (!preferences.getBoolean("source_UC", true)) {
 			sourceList.add("Ultimate Combat");
 		}
-		if (preferences.getBoolean("source_UE", true) == false) {
+		if (!preferences.getBoolean("source_UE", true)) {
 			sourceList.add("Ultimate Equipment");
 		}
-		if (preferences.getBoolean("source_UM", true) == false) {
+		if (!preferences.getBoolean("source_UM", true)) {
 			sourceList.add("Ultimate Magic");
 		}
-		if (preferences.getBoolean("source_MA", true) == false) {
+		if (!preferences.getBoolean("source_MA", true)) {
 			sourceList.add("Mythic Adventures");
 		}
-		if (preferences.getBoolean("source_OA", true) == false) {
+		if (!preferences.getBoolean("source_OA", true)) {
 			sourceList.add("Occult Adventures");
 		}
-		if (preferences.getBoolean("source_TG", true) == false) {
+		if (!preferences.getBoolean("source_TG", true)) {
 			sourceList.add("Technology Guide");
 		}
-		if (preferences.getBoolean("source_B1", true) == false) {
+		if (!preferences.getBoolean("source_B1", true)) {
 			sourceList.add("Bestiary");
 		}
-		if (preferences.getBoolean("source_B2", true) == false) {
+		if (!preferences.getBoolean("source_B2", true)) {
 			sourceList.add("Bestiary 2");
 		}
-		if (preferences.getBoolean("source_B3", true) == false) {
+		if (!preferences.getBoolean("source_B3", true)) {
 			sourceList.add("Bestiary 3");
 		}
-		if (preferences.getBoolean("source_B4", true) == false) {
+		if (!preferences.getBoolean("source_B4", true)) {
 			sourceList.add("Bestiary 4");
 		}
-		if (preferences.getBoolean("source_GMG", true) == false) {
+		if (!preferences.getBoolean("source_GMG", true)) {
 			sourceList.add("Game Mastery Guide");
 		}
-		if (preferences.getBoolean("source_PFU", true) == false) {
+		if (!preferences.getBoolean("source_PFU", true)) {
 			sourceList.add("Pathfinder Unchained");
 		}
-		if (preferences.getBoolean("source_NPC", true) == false) {
+		if (!preferences.getBoolean("source_NPC", true)) {
 			sourceList.add("NPC Codex");
 		}
-		if (preferences.getBoolean("source_MC", true) == false) {
+		if (!preferences.getBoolean("source_MC", true)) {
 			sourceList.add("Monster Codex");
 		}
 		if (sourceList.size() > 0) {

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/HtmlRenderer.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/HtmlRenderer.java
@@ -53,7 +53,7 @@ public abstract class HtmlRenderer {
 		this.alt = FullSectionAdapter.SectionUtils.getAlt(cursor);
 		localSetValues();
 		StringBuffer sb = new StringBuffer();
-		if (suppressTitle == false) {
+		if (!suppressTitle) {
 			sb.append(renderTitle());
 		}
 		sb.append(renderImage());


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1125- “Literal boolean values should not be used in condition expressions”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1125
Please let me know if you have any questions.
Ayman Abdelghany.