### PR TITLE
Useless parentheses around expressions should be removed

### DIFF
--- a/app/src/main/java/org/evilsoft/pathfinder/reference/api/AbstractContentProvider.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/api/AbstractContentProvider.java
@@ -90,11 +90,11 @@ public abstract class AbstractContentProvider extends ContentProvider {
 
 		for (String extension : MIME_TYPES.keySet()) {
 			if (path.endsWith(extension)) {
-				return (MIME_TYPES.get(extension));
+				return MIME_TYPES.get(extension);
 			}
 		}
 
-		return (null);
+		return null;
 	}
 
 	public String renderHtmlByIndexId(String indexId) {
@@ -206,7 +206,7 @@ public abstract class AbstractContentProvider extends ContentProvider {
 			throw new FileNotFoundException("Could not open pipe for: "
 					+ uri.toString());
 		}
-		return (pipe[0]);
+		return pipe[0];
 	}
 
 	@Override

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/list/SkillListAdapter.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/list/SkillListAdapter.java
@@ -45,8 +45,8 @@ public class SkillListAdapter extends DisplayListAdapter {
 			TextView description = (TextView) V.findViewById(R.id.skill_list_description);
 			String desc = IndexGroupAdapter.IndexGroupUtils.getDescription(c);
 			description.setText(SkillListItem.shortDescription(desc));
-			boolean armorCheckPenalty = (IndexGroupAdapter.IndexGroupUtils.getSkillArmor(c) != 0);
-			boolean trainedOnly = (IndexGroupAdapter.IndexGroupUtils.getSkillTrained(c) != 0);
+			boolean armorCheckPenalty = IndexGroupAdapter.IndexGroupUtils.getSkillArmor(c) != 0;
+			boolean trainedOnly = IndexGroupAdapter.IndexGroupUtils.getSkillTrained(c) != 0;
 			TextView qualities = (TextView) V.findViewById(R.id.skill_list_qualities);
 			qualities.setText(SkillListItem.buildQualitiesDisplay(armorCheckPenalty, trainedOnly));
 		}
@@ -61,8 +61,8 @@ public class SkillListAdapter extends DisplayListAdapter {
 		String url = IndexGroupAdapter.IndexGroupUtils.getUrl(c);
 		String description = IndexGroupAdapter.IndexGroupUtils.getDescription(c);
 		String attribute = IndexGroupAdapter.IndexGroupUtils.getSkillAttr(c);
-		boolean armorCheckPenalty = (IndexGroupAdapter.IndexGroupUtils.getSkillArmor(c) != 0);
-		boolean trainedOnly = (IndexGroupAdapter.IndexGroupUtils.getSkillTrained(c) != 0);
+		boolean armorCheckPenalty = IndexGroupAdapter.IndexGroupUtils.getSkillArmor(c) != 0;
+		boolean trainedOnly = IndexGroupAdapter.IndexGroupUtils.getSkillTrained(c) != 0;
 		return buildSkill(sectionId, database, name, url, description,
 				attribute, armorCheckPenalty, trainedOnly);
 	}

--- a/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/SkillRenderer.java
+++ b/app/src/main/java/org/evilsoft/pathfinder/reference/render/html/SkillRenderer.java
@@ -35,11 +35,11 @@ public class SkillRenderer extends HtmlRenderer {
 			if (has_next) {
 				sb.append("<H2>(");
 				sb.append(SkillAdapter.SkillUtils.getAttribute(cursor));
-				boolean armorCheckPenalty = (SkillAdapter.SkillUtils.getArmorCheckPenalty(cursor) != 0);
+				boolean armorCheckPenalty = SkillAdapter.SkillUtils.getArmorCheckPenalty(cursor) != 0;
 				if (armorCheckPenalty) {
 					sb.append("; Armor Check Penalty");
 				}
-				boolean trainedOnly = (SkillAdapter.SkillUtils.getTrainedOnly(cursor) != 0);
+				boolean trainedOnly = SkillAdapter.SkillUtils.getTrainedOnly(cursor) != 0;
 				if (trainedOnly) {
 					sb.append("; Trained Only");
 				}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessParenthesesCheck - “ Useless parentheses around expressions should be removed to prevent any misunderstanding ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
Ayman Abdelghany.